### PR TITLE
Mutli nested gitignores

### DIFF
--- a/src/gitignore.rs
+++ b/src/gitignore.rs
@@ -32,7 +32,21 @@ pub enum Error {
     Io(io::Error),
 }
 
-pub fn parse(path: &Path) -> Result<PatternSet, Error> {
+pub fn parse(paths: &[PathBuf]) -> Result<PatternSet, Error> {
+    let mut all_patterns = Vec::new();
+
+    for path in paths {
+        let file_patterns = try!(parse_file(path));
+
+        for pattern in file_patterns {
+            all_patterns.push(pattern);
+        }
+    }
+
+    Ok(PatternSet::new(all_patterns))
+}
+
+fn parse_file(path: &Path) -> Result<Vec<Pattern>, Error> {
     let mut file = try!(fs::File::open(path));
     let mut contents = String::new();
     try!(file.read_to_string(&mut contents));
@@ -46,7 +60,7 @@ pub fn parse(path: &Path) -> Result<PatternSet, Error> {
         .map(|l| Pattern::new(l, root))
         .collect());
 
-    Ok(PatternSet::new(patterns))
+    Ok(patterns)
 }
 
 impl PatternSet {
@@ -166,18 +180,6 @@ impl From<io::Error> for Error {
         Error::Io(error)
     }
 }
-
-//fn main() {
-    //let cwd = env::current_dir().unwrap();
-    //let gitignore_file = cwd.join(".gitignore");
-    //let file = File::new(&gitignore_file).unwrap();
-
-    //for arg in env::args().skip(1) {
-        //let path = cwd.join(&arg);
-        //let matches = file.is_excluded(&path);
-        //println!("File: {}, Excluded: {}", arg, matches);
-    //}
-//}
 
 #[cfg(test)]
 mod tests {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -26,11 +26,11 @@ impl Runner {
     }
 
     #[cfg(target_family = "windows")]
-    fn invoke(&self, cmd: &str, updated_paths: Vec<&str>) -> Option<Child> {
+    fn invoke(&self, cmd: &str, updated_paths: &[&str]) -> Option<Child> {
         let mut command = Command::new("cmd.exe");
         command.arg("/C").arg(cmd);
 
-        if updated_files.len() > 0 {
+        if !updated_paths.is_empty() {
             command.env("WATCHEXEC_UPDATED_PATH", updated_paths[0]);
         }
 
@@ -38,18 +38,18 @@ impl Runner {
     }
 
     #[cfg(target_family = "unix")]
-    fn invoke(&self, cmd: &str, updated_paths: Vec<&str>) -> Option<Child> {
+    fn invoke(&self, cmd: &str, updated_paths: &[&str]) -> Option<Child> {
         let mut command = Command::new("sh");
         command.arg("-c").arg(cmd);
 
-        if updated_paths.len() > 0 {
+        if !updated_paths.is_empty() {
             command.env("WATCHEXEC_UPDATED_PATH", updated_paths[0]);
         }
 
         command.spawn().ok()
     }
 
-    pub fn run_command(&mut self, cmd: &str, updated_paths: Vec<&str>) {
+    pub fn run_command(&mut self, cmd: &str, updated_paths: &[&str]) {
         if let Some(ref mut child) = self.process {
             if self.restart {
                 debug!("Killing child process (pid: {})", child.id());


### PR DESCRIPTION
I was looking at the code and I noticed that it only looks for a single gitignore. It looked like it was checking the current path's parent if no gitignore file was found? 

Is that the correct behavior? Shouldn't you be checking the current path's children (and nested) instead?

Also, if you are watching a directory with multiple repos, you might want to consider multiple gitignore files instead of only letting the first one win. 

I haven't actually confirmed that this works, I kind of just threw this together. I'll take a closer look within the next few days. 

If you don't agree with the changes, you or I can close this. 