### PR TITLE
README: Add rustup command for installing with nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,14 @@ Run `make` when any file changes, using the `.gitignore` file in the current dir
 
 ###Cargo (nightly Rust only)
 
+If you're running nightly Rust, install it using cargo:
+
     $ cargo install watchexec
+
+If you're using rustup, install it like this:
+
+    $ rustup toolchain install nightly
+    $ rustup run nightly cargo install watchexec
 
 ###OS X with Homebrew
 


### PR DESCRIPTION
I had to figure out how to install watchexec with nightly using rustup.
A lot of people are probably not familiar with it, so include the commands.