### PR TITLE
Resolving conflicted cargo documents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,7 @@ nix = "0.7.0"
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.8"
 kernel32-sys = "0.2.2"
+
+[[bin]]
+name = "watchexec"
+doc = false


### PR DESCRIPTION
Hi, maintainers.
This pull request will disable bin's document. The reason why is that I caught the following error with `cargo doc`, `cargo doc --lib` and `cargo doc --bin watchexec`.
> error: cannot document a package where a library and a binary have the same name. Consider renaming one or marking the target as `doc = false`