### PR TITLE
update details

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,5 +25,6 @@ mod process;
 pub mod run;
 mod signal;
 mod watcher;
+mod pathop;
 
 pub use run::run;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod process;
 mod run;
 mod signal;
 mod watcher;
+mod pathop;
 
 fn main() {
     let args = cli::get_args();

--- a/src/pathop.rs
+++ b/src/pathop.rs
@@ -1,0 +1,44 @@
+use notify::op;
+use std::path::{Path, PathBuf};
+
+
+/// Info about a path and its corresponding `notify` event
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub struct PathOp {
+    pub path: PathBuf,
+    pub op: Option<op::Op>,
+    pub cookie: Option<u32>,
+}
+
+impl PathOp {
+    pub fn new(path: &Path, op: Option<op::Op>, cookie: Option<u32>) -> PathOp {
+        PathOp {
+            path: path.to_path_buf(),
+            op: op,
+            cookie: cookie,
+        }
+    }
+
+    pub fn is_create(op_: op::Op) -> bool {
+        op_.contains(op::CREATE)
+    }
+
+    pub fn is_remove(op_: op::Op) -> bool {
+        op_.contains(op::REMOVE)
+    }
+
+    pub fn is_rename(op_: op::Op) -> bool {
+        op_.contains(op::RENAME)
+    }
+
+    pub fn is_write(op_: op::Op) -> bool {
+        let mut write_or_close_write = op::WRITE;
+        write_or_close_write.toggle(op::CLOSE_WRITE);
+        op_.intersects(write_or_close_write)
+    }
+
+    pub fn is_meta(op_: op::Op) -> bool {
+        op_.contains(op::CHMOD)
+    }
+}
+


### PR DESCRIPTION
So I started looking into this (issue #59). There's a lot of cleanup that still needs to be done, I just wanted to open this to bring up some questions.

You can give it a spin with `cargo run -- 'printenv | rg WATCHEXEC && echo ""'` and then `touch src/main.rs src/process.rs src/watcher.rs` to see some output:

```
WATCHEXEC_COMMON_PATH=/home/james/projects/rust/watchexec/src
WATCHEXEC_WRITTEN_PATH=/main.rs:/process.rs:/watcher.rs
WATCHEXEC_META_CHANGED_PATH=/main.rs:/process.rs:/watcher.rs
```

Right now I'm just dumping all events for each category:
```
WRITTEN -> notify::ops::WRITE, notify::ops::CLOSE_WRITE
META_CHANGED -> notify::ops::CHMOD
REMOVED -> notify::ops::REMOVE
CREATED -> notify::ops::CREATE
RENAMED -> notify::ops::RENAME
``` 

So things get a little hairy with intermediary files that are being created/renamed/removed on each file save. Here's a sample of some events that happen when I save one file:

```
    PathOp {
        path: "/home/james/projects/rust/watchexec/src/run.rs",
        op: Some(
            RENAME
        ),
        cookie: Some(
            237613
        )
    },
    PathOp {
        path: "/home/james/projects/rust/watchexec/src/run.rs~",
        op: Some(
            RENAME
        ),
        cookie: Some(
            237613
        )
    },
    PathOp {
        path: "/home/james/projects/rust/watchexec/src/run.rs",
        op: Some(
            CREATE
        ),
        cookie: None
    },
    PathOp {
        path: "/home/james/projects/rust/watchexec/src/run.rs",
        op: Some(
            WRITE
        ),
        cookie: None
    },
    PathOp {
        path: "/home/james/projects/rust/watchexec/src/run.rs",
        op: Some(
            CLOSE_WRITE
        ),
        cookie: None
    },
    PathOp {
        path: "/home/james/projects/rust/watchexec/src/run.rs",
        op: Some(
            CHMOD
        ),
        cookie: None
    },
    PathOp {
        path: "/home/james/projects/rust/watchexec/src/run.rs~",
        op: Some(
            REMOVE
        ),
        cookie: None
    }
```

I guess at this point I'm wondering if it's worth trying to:
* pair up `rename`s
* track and filter out items that were `created`, possibly `renamed` a couple times, and then `removed` during the timeout.

Or just pass on everything and not worry about it