### PR TITLE
Use `tput reset` to clear screen.

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,7 @@ pub fn clear_screen() {
 
 #[cfg(target_family = "unix")]
 pub fn clear_screen() {
-    let _ = Command::new("clear").status();
+    let _ = Command::new("tput").arg("reset").status();
 }
 
 #[allow(unknown_lints)]


### PR DESCRIPTION
Use `tput reset` instead of `clear` so that scrollback is cleared in
addition to the currently visible portion of the terminal.

(Should this fallback to clear if `tput reset` fails? `tput reset` is mandated by [POSIX](http://pubs.opengroup.org/onlinepubs/009695399/utilities/tput.html) and seems to be available on basically everything even remotely unixy (except Android), so it probably isn't worth it.)